### PR TITLE
Fix cookie manager

### DIFF
--- a/example/test_driver/tests/cookie_manager_test.dart
+++ b/example/test_driver/tests/cookie_manager_test.dart
@@ -106,14 +106,11 @@ void main() {
 
       sleep(Duration(seconds: 2));
 
-      // TODO: It doesn't work on iOS, so I'll temporarily skip it.
-      if (Platform.isAndroid) {
-        final cookies2 = await cookieManager.getCookies(
-          url: currentUrl,
-          name: "myCookie",
-        );
-        expect(cookies2.length, 0);
-      }
+      final cookies2 = await cookieManager.getCookies(
+        url: currentUrl,
+        name: "myCookie",
+      );
+      expect(cookies2.length, 0);
 
       context.complete();
     });
@@ -187,7 +184,7 @@ void main() {
       context.complete();
     });
 
-    testWebView('Specify domain', (tester, context) async {
+    testWebView('specify domain', (tester, context) async {
       await tester.pumpWidget(
         WebView(
           initialUrl: 'https://en.wikipedia.org/wiki/Flutter_(software)',
@@ -196,7 +193,7 @@ void main() {
       );
 
       final controller = await context.webviewController.future;
-      final currentUrl = await controller.currentUrl();
+      var currentUrl = await controller.currentUrl();
       final cookieManager = CookieManager.instance();
       final emptyCookies = await cookieManager.getCookies(
         url: currentUrl,
@@ -213,6 +210,7 @@ void main() {
       );
 
       await controller.loadUrl("https://ja.wikipedia.org/wiki/Flutter");
+      currentUrl = await controller.currentUrl();
 
       final cookies = await cookieManager.getCookies(
         url: currentUrl,

--- a/example/test_driver/tests/cookie_manager_test.dart
+++ b/example/test_driver/tests/cookie_manager_test.dart
@@ -186,6 +186,43 @@ void main() {
       expect(cookies.first.value, "myValue");
       context.complete();
     });
+
+    testWebView('Specify domain', (tester, context) async {
+      await tester.pumpWidget(
+        WebView(
+          initialUrl: 'https://en.wikipedia.org/wiki/Flutter_(software)',
+          onWebViewCreated: context.onWebViewCreated,
+        ),
+      );
+
+      final controller = await context.webviewController.future;
+      final currentUrl = await controller.currentUrl();
+      final cookieManager = CookieManager.instance();
+      final emptyCookies = await cookieManager.getCookies(
+        url: currentUrl,
+        name: "myCookie",
+      );
+      expect(emptyCookies.length, 0);
+
+      await cookieManager.setCookie(
+        url: currentUrl,
+        name: "myCookie",
+        value: "myValue",
+        domain: ".wikipedia.org",
+        isSecure: true,
+      );
+
+      await controller.loadUrl("https://ja.wikipedia.org/wiki/Flutter");
+
+      final cookies = await cookieManager.getCookies(
+        url: currentUrl,
+        name: "myCookie",
+      );
+      expect(cookies.length, 1);
+      expect(cookies.first.name, "myCookie");
+      expect(cookies.first.value, "myValue");
+      context.complete();
+    });
   });
 
   testWebView('deleteCookie', (tester, context) async {

--- a/ios/Classes/CookieManager.swift
+++ b/ios/Classes/CookieManager.swift
@@ -24,8 +24,8 @@ class CookieManager: NSObject, FlutterPlugin {
                 let value = arguments["value"] as! String
                 let domain = arguments["domain"] as! String
                 let path = arguments["path"] as! String
-                let expiresDate = arguments["expiresDate"] as? Int
-                let maxAge = arguments["maxAge"] as? Int
+                let expiresDate = (arguments["expiresDate"] as? String).flatMap({ Int($0) }) ?? arguments["expiresDate"] as? Int
+                let maxAge = (arguments["maxAge"] as? String).flatMap({ Int($0) }) ?? arguments["maxAge"] as? Int
                 let isSecure = arguments["isSecure"] as? Bool
 
                 setCookie(url: url, name: name, value: value, domain: domain, path: path, expiresDate: expiresDate, maxAge: maxAge, isSecure: isSecure, result: result)
@@ -80,7 +80,7 @@ class CookieManager: NSObject, FlutterPlugin {
             properties[.expires] = NSDate(timeIntervalSince1970: Double(expiresDate))
         }
         if let maxAge = maxAge {
-            properties[.maximumAge] = String(maxAge)
+            properties[.maximumAge] = maxAge
         }
 
         // https://github.com/pichillilorenzo/flutter_inappwebview/pull/311

--- a/ios/Classes/CookieManager.swift
+++ b/ios/Classes/CookieManager.swift
@@ -74,7 +74,7 @@ class CookieManager: NSObject, FlutterPlugin {
         properties[.originURL] = url
         properties[.name] = name
         properties[.value] = value
-        properties[.domain] = domain
+        properties[.domain] = domain.hasPrefix(".") ? domain : ".\(domain)"
         properties[.path] = path
         if let expiresDate = expiresDate {
             properties[.expires] = NSDate(timeIntervalSince1970: Double(expiresDate))

--- a/ios/Classes/CookieManager.swift
+++ b/ios/Classes/CookieManager.swift
@@ -101,7 +101,9 @@ class CookieManager: NSObject, FlutterPlugin {
         var cookieList: [[String: Any]] = []
         httpCookieStore.getAllCookies { (cookies) in
             for cookie in cookies {
-                if cookie.domain.contains(URL(string: url)!.host!) {
+                var domain = cookie.domain
+                domain = domain.hasPrefix(".") ? String(domain.suffix(domain.count - 1)) : domain
+                if let host = URL(string: url)?.host, host.hasSuffix(domain) {
                     cookieList.append([
                         "name": cookie.name,
                         "value": cookie.value

--- a/lib/src/cookie_manager.dart
+++ b/lib/src/cookie_manager.dart
@@ -36,7 +36,7 @@ class CookieManager {
     int maxAge,
     bool isSecure,
   }) async {
-    if (domain == null || domain.isNotEmpty) domain = _getDomainName(url);
+    if (domain == null || domain.isEmpty) domain = _getDomainName(url);
 
     assert(url != null && url.isNotEmpty);
     assert(name != null && name.isNotEmpty);
@@ -134,6 +134,6 @@ class CookieManager {
     Uri uri = Uri.parse(url);
     String domain = uri.host;
     if (domain == null) return "";
-    return domain.startsWith("www.") ? domain.substring(4) : domain;
+    return domain.startsWith("www.") ? domain.substring(3) : domain;
   }
 }

--- a/lib/src/cookie_manager.dart
+++ b/lib/src/cookie_manager.dart
@@ -134,6 +134,6 @@ class CookieManager {
     Uri uri = Uri.parse(url);
     String domain = uri.host;
     if (domain == null) return "";
-    return domain.startsWith("www.") ? domain.substring(3) : domain;
+    return domain.startsWith("www.") ? domain.substring(4) : domain;
   }
 }


### PR DESCRIPTION
The following bugs have been fixeed.

- `expiresDate`, `maxAge` settings are ignored on iOS
- The `domain` setting is not working on both OSs