### PR TITLE
[cookie]Change the behavior when domain is not set

### DIFF
--- a/android/src/main/kotlin/com/hisaichi5518/native_webview/CookieManager.kt
+++ b/android/src/main/kotlin/com/hisaichi5518/native_webview/CookieManager.kt
@@ -63,7 +63,7 @@ class MyCookieManager(messenger: BinaryMessenger?) : MethodCallHandler {
         result: MethodChannel.Result
     ) {
         var cookieValue = "$name=$value; Path=$path"
-        if (domain != null) cookieValue += "; Domain=$domain;"
+        if (domain != null) cookieValue += "; Domain=$domain"
         if (maxAge != null) cookieValue += "; Max-Age=$maxAge"
         if (isSecure != null && isSecure) cookieValue += "; Secure"
         cookieValue += ";"

--- a/android/src/main/kotlin/com/hisaichi5518/native_webview/CookieManager.kt
+++ b/android/src/main/kotlin/com/hisaichi5518/native_webview/CookieManager.kt
@@ -62,7 +62,8 @@ class MyCookieManager(messenger: BinaryMessenger?) : MethodCallHandler {
         isSecure: Boolean?,
         result: MethodChannel.Result
     ) {
-        var cookieValue = "$name=$value; Domain=$domain; Path=$path"
+        var cookieValue = "$name=$value; Path=$path"
+        if (domain != null) cookieValue += "; Domain=$domain;"
         if (maxAge != null) cookieValue += "; Max-Age=$maxAge"
         if (isSecure != null && isSecure) cookieValue += "; Secure"
         cookieValue += ";"

--- a/ios/Classes/CookieManager.swift
+++ b/ios/Classes/CookieManager.swift
@@ -22,7 +22,7 @@ class CookieManager: NSObject, FlutterPlugin {
                 let url = arguments["url"] as! String
                 let name = arguments["name"] as! String
                 let value = arguments["value"] as! String
-                let domain = arguments["domain"] as! String
+                let domain = arguments["domain"] as? String
                 let path = arguments["path"] as! String
                 let maxAge = arguments["maxAge"] as? String
                 let isSecure = arguments["isSecure"] as? Bool
@@ -62,7 +62,7 @@ class CookieManager: NSObject, FlutterPlugin {
         url: String,
         name: String,
         value: String,
-        domain: String,
+        domain: String?,
         path: String,
         maxAge: String?,
         isSecure: Bool?,
@@ -72,8 +72,11 @@ class CookieManager: NSObject, FlutterPlugin {
         properties[.originURL] = url
         properties[.name] = name
         properties[.value] = value
-        properties[.domain] = domain.hasPrefix(".") ? domain : ".\(domain)"
         properties[.path] = path
+
+        if let domain = domain {
+            properties[.domain] = domain.hasPrefix(".") ? domain : ".\(domain)"
+        }
 
         if let maxAge = maxAge {
             properties[.maximumAge] = maxAge

--- a/lib/src/cookie_manager.dart
+++ b/lib/src/cookie_manager.dart
@@ -35,12 +35,9 @@ class CookieManager {
     Duration maxAge,
     bool isSecure,
   }) async {
-    if (domain == null || domain.isEmpty) domain = _getDomainName(url);
-
     assert(url != null && url.isNotEmpty);
     assert(name != null && name.isNotEmpty);
     assert(value != null && value.isNotEmpty);
-    assert(domain != null && domain.isNotEmpty);
     assert(path != null && path.isNotEmpty);
 
     Map<String, dynamic> args = <String, dynamic>{


### PR DESCRIPTION
Currently, CookieManager sets the domain from the `url` if the `domain` is not specified.
There is a problem with this behavior. It is always a cookie sent to the subdomain host.
In some cases, a user want to send a cookie only to a host with a cookie set.

To resolve this issue, CookieManager issues a cookie to the host if the user does not specify a `domain`. This is the same behavior as the browser's Set-Cookie. 