### PR TITLE
Fix scroll bar appearing above contents problem

### DIFF
--- a/ios/Classes/NativeWebView.swift
+++ b/ios/Classes/NativeWebView.swift
@@ -16,6 +16,10 @@ public class NativeWebView: WKWebView {
         navigationDelegate = self
         uiDelegate = self
 
+        if #available(iOS 13.0, *) {
+            self.scrollView.automaticallyAdjustsScrollIndicatorInsets = false
+        }
+
         addObserver(
             self,
             forKeyPath: #keyPath(WKWebView.estimatedProgress),


### PR DESCRIPTION
Fixed an issue that scrollbar appear above the contents. And, I have confirmed this problem happen in not only simulator but real device(iPhone11 iOS13.3.1). It’s probably happen in notched iOS devices.  

I found the same issue have occurred in webview_flutter(cf: https://github.com/flutter/flutter/issues/41592), so I tried to fix it with the same approach(cf: https://github.com/flutter/plugins/pull/2343). And It’s worked ☺️